### PR TITLE
Fixed an issue where the collection predicate would be be set to `''`.

### DIFF
--- a/Sage.SData.Client/Core/SDataSingleResourceRequest.cs
+++ b/Sage.SData.Client/Core/SDataSingleResourceRequest.cs
@@ -154,7 +154,7 @@ namespace Sage.SData.Client.Core
             {
                 var payload = Entry.GetSDataPayload();
 
-                if (payload != null)
+                if (payload != null && !String.IsNullOrEmpty(payload.Key))
                 {
                     uri.CollectionPredicate = string.Format("'{0}'", payload.Key);
                 }


### PR DESCRIPTION
This is a fix for an issue where the collection predicate is set to `''` when creating a new entry using the `SDataSingleResourceRequest`.

When the collection predicate is set to `''` it causes the URL for the POST request to become `/resource('')`.
